### PR TITLE
remove transitions for elements

### DIFF
--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -8,6 +8,4 @@
   font-weight: $weight;
   padding: 0.75rem 1.5rem;
   border-radius: $round;
-  transition: 100ms ease-in-out;
-  transition-property: color, background, background-color;
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -94,7 +94,7 @@ h4 {
 
   &__links--link__icon {
     display: block;
-    transition: 100ms ease-in-out;
+    // transition: 100ms ease-in-out;
 
     & img {
       width: 1.05rem;


### PR DESCRIPTION
# What's removed
`transition` has been removed for buttons, links, etc. The previously added transition looked unmatching with the page. So, elements will have quick interactions from this PR onwards.
